### PR TITLE
Fix depth handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,6 +35,10 @@ let {
   excludeGlobPatterns,
 } = await Actor.getInput();
 
+// Our APIs interpret "maxDepth = 1" as "only crawl the direct source" but
+// Playwright uses 0 for this meaning. This corrects the off-by-one difference.
+maxCrawlDepth = Math.max(maxCrawlDepth - 1, 0);
+
 console.log(`Requested maxCrawlDepth is ${maxCrawlDepth}`);
 console.log(`Requested maxCrawlPages is ${maxCrawlPages}`);
 console.log(`Requested datasetName is ${datasetName}`);


### PR DESCRIPTION
Related to https://app.datadoghq.com/event/explorer?cols=&event=AwAAAZTf24Bg7SywaQAAABhBWlRmMjRROUFBRFRBZVFCSDdLcTVvOTMAAAAkMDE5NGRmZGItODA2MC00MTIwLWI1MWItMDRjOGRmMjgzOGM1AAAAAA&link_source=monitor_notif&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&view=all&from_ts=1738915200000&to_ts=1738922882000&live=false which was caused by Apify timing out.

Apify could still time out, but fixing the crawl depth makes that much less likely for usual requests.