### PR TITLE
Try to fix mime types again

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,11 +187,6 @@ async function getPublished(page) {
   );
 }
 
-/** Get the MIME type of this response. */
-async function getMimeType(response) {
-  return await response.headerValue("content-type");
-}
-
 // Configure Apify proxy.
 const proxyConfiguration = await Actor.createProxyConfiguration({
   groups: ['AUTO'],
@@ -245,7 +240,7 @@ const crawler = new PlaywrightCrawler({
       description: await getDescription(page),
       language: await getLanguage(page, response),
       published: await getPublished(page),
-      mime_type: await getMimeType(response),
+      mime_type: await response.headerValue("content-type"),
       content_length: await response.headerValue("content-length"),
       content: await page.content(),
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
Some observations:

1. The "response" object for downloads is not the same as the one for regular requests.
2. Old data suggests we've never gotten a header value from a regular request that wasn't undefined.
3. Corpus service treats missing mime types as text/html when loading Apify results (hence this working before despite item 2).
4. Regular requests won't download attachments, so we should just trust the server content-type in that case.

This should fix everything since #5, while incorporating useful changes made in the interim.